### PR TITLE
Capitalize acronyms in labels

### DIFF
--- a/Gedcom551/Program.cs
+++ b/Gedcom551/Program.cs
@@ -40,7 +40,10 @@ namespace Gedcom551
                         {
                             string label = longname.Replace('_', ' ').ToLower();
                             string label2 = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(label);
-                            schema.Label = label2;
+                            string label3 = label2.Replace("Lds", "LDS");
+                            label3 = label3.Replace("Gedcom", "GEDCOM");
+                            label3 = label3.Replace("Afn", "AFN");
+                            schema.Label = label3;
                         }
                     }
                     else if (lastTag != string.Empty)

--- a/output/structure/standard/AFN.yaml
+++ b/output/structure/standard/AFN.yaml
@@ -11,7 +11,7 @@ standard tag: 'AFN'
 specification:
   - A unique permanent record file number of an individual record stored in Ancestral File.
 
-label: 'Afn'
+label: 'AFN'
 
 payload: https://gedcom.io/terms/v5.5.1/type-ANCESTRAL_FILE_NUMBER
 

--- a/output/structure/standard/BAPL.yaml
+++ b/output/structure/standard/BAPL.yaml
@@ -11,7 +11,7 @@ standard tag: 'BAPL'
 specification:
   - The event of baptism performed at age eight or later by priesthood authority of the LDS Church. (See also BAPM, next)
 
-label: 'Baptism-Lds'
+label: 'Baptism-LDS'
 
 payload: null
 

--- a/output/structure/standard/CONL.yaml
+++ b/output/structure/standard/CONL.yaml
@@ -11,7 +11,7 @@ standard tag: 'CONL'
 specification:
   - The religious event by which a person receives membership in the LDS Church.
 
-label: 'Confirmation Lds'
+label: 'Confirmation LDS'
 
 payload: null
 

--- a/output/structure/standard/GEDC.yaml
+++ b/output/structure/standard/GEDC.yaml
@@ -11,7 +11,7 @@ standard tag: 'GEDC'
 specification:
   - Information about the use of GEDCOM in a transmission.
 
-label: 'Gedcom'
+label: 'GEDCOM'
 
 payload: null
 


### PR DESCRIPTION
Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None

- **Bug Fixes**
	- Corrected label capitalization for several GEDCOM-related terms:
		- Updated 'Afn' to 'AFN'
		- Updated 'Baptism-Lds' to 'Baptism-LDS'
		- Updated 'Confirmation Lds' to 'Confirmation LDS'
		- Updated 'Gedcom' to 'GEDCOM'

- **Documentation**
	- Improved consistency in label formatting across GEDCOM standard files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->