### PR TITLE
Handle nested types

### DIFF
--- a/Gedcom551/Construct/GedcomStructureSchema.cs
+++ b/Gedcom551/Construct/GedcomStructureSchema.cs
@@ -64,6 +64,10 @@ namespace Gedcom551.Construct
                     {
                         return true;
                     }
+                    if (line.StartsWith('<'))
+                    {
+                        return true;
+                    }
                 }
                 return false;
             }

--- a/Tests/SchemaTests.cs
+++ b/Tests/SchemaTests.cs
@@ -137,6 +137,12 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TestChanDate()
+        {
+            VerifyQualifiedTag("CHAN", "DATE", "CHANGE_DATE");
+        }
+
+        [TestMethod]
         public void TestMultimediaRecordFileForm()
         {
             VerifyQualifiedTag("OBJE-FILE", "FORM");

--- a/output/structure/standard/CHAN-DATE.yaml
+++ b/output/structure/standard/CHAN-DATE.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_EXACT>
-    The date that this data was changed.
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-CHANGE_DATE
 
 substructures:
   "https://gedcom.io/terms/v5.5.1/TIME": "{0:1}"

--- a/output/structure/standard/DATE-CHANGE_DATE.yaml
+++ b/output/structure/standard/DATE-CHANGE_DATE.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_EXACT>
-    The date that this data was changed.
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-CHANGE_DATE
 
 substructures: {}
 

--- a/output/structure/standard/DATE-DATE_LDS_ORD.yaml
+++ b/output/structure/standard/DATE-DATE_LDS_ORD.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_VALUE>
-    LDS ordinance dates use only the Gregorian date and most often use the form of day, month, and year. Only in rare instances is there a partial date. The temple tag and code should always accompany temple ordinance dates. Sometimes the LDS_(ordinance)_DATE_STATUS is used to indicate that an ordinance date and temple code is not required, such as when BIC is used. (See LDS_(ordinance)_DATE_STATUS definitions beginning on page 51.)
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-DATE_LDS_ORD
 
 substructures: {}
 

--- a/output/structure/standard/HEAD-DATE.yaml
+++ b/output/structure/standard/HEAD-DATE.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_EXACT>
-    The date that this transmission was created.
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-TRANSMISSION_DATE
 
 substructures:
   "https://gedcom.io/terms/v5.5.1/TIME": "{0:1}"

--- a/output/structure/standard/HEAD-SOUR-DATA-DATE.yaml
+++ b/output/structure/standard/HEAD-SOUR-DATA-DATE.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_EXACT>
-    The date this source was published or created.
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-PUBLICATION_DATE
 
 substructures: {}
 

--- a/output/structure/standard/INDI-RFN.yaml
+++ b/output/structure/standard/INDI-RFN.yaml
@@ -10,13 +10,10 @@ standard tag: 'RFN'
 
 specification:
   - A permanent number assigned to a record that uniquely identifies it within a known file.
-  - |
-    <REGISTERED_RESOURCE_IDENTIFIER>:<RECORD_IDENTIFIER>
-    "The record number that uniquely identifies this record within a registered network resource. The number will be usable as a cross-reference pointer. The use of the colon (:) is reserved to indicate the separation of the \"registered resource identifier\" (which precedes the colon) and the unique \"record identifier\" within that resource (which follows the colon). If the colon is used, implementations that check pointers should not expect to find a matching cross-reference identifier in the transmission but would find it in the indicated database within a network. Making resource files available to a public network is a future implementation."
 
 label: 'Rec File Number'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-PERMANENT_RECORD_FILE_NUMBER
 
 substructures: {}
 

--- a/output/structure/standard/PLAC-PLACE_LIVING_ORDINANCE.yaml
+++ b/output/structure/standard/PLAC-PLACE_LIVING_ORDINANCE.yaml
@@ -10,13 +10,10 @@ standard tag: 'PLAC'
 
 specification:
   - A jurisdictional name to identify the place or location of an event.
-  - |
-    <PLACE_NAME>
-    The locality of the place where a living LDS ordinance took place. Typically, a living LDS baptism place would be recorded in this field.
 
 label: 'Place'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-PLACE_LIVING_ORDINANCE
 
 substructures: {}
 

--- a/output/structure/standard/PLAC-PLACE_NAME-FONE.yaml
+++ b/output/structure/standard/PLAC-PLACE_NAME-FONE.yaml
@@ -10,13 +10,10 @@ standard tag: 'FONE'
 
 specification:
   - A phonetic variation of a superior text string
-  - |
-    The phonetic variation of the place name is written in the same form as was the place name used in the superior <PLACE_NAME> primitive, but phonetically written using the method indicated by the subordinate <PHONETIC_TYPE> value, for example if hiragana was used to provide a reading of a a name written in kanji, then the <PHONETIC_TYPE> value would indicate kana. (See
-    <PHONETIC_TYPE> page 57.)
 
 label: 'Phonetic'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-PLACE_PHONETIC_VARIATION
 
 substructures:
   "https://gedcom.io/terms/v5.5.1/TYPE-PHONETIC_TYPE": "{1:1}"

--- a/output/structure/standard/SOUR-DATA-EVEN-PLAC.yaml
+++ b/output/structure/standard/SOUR-DATA-EVEN-PLAC.yaml
@@ -10,13 +10,10 @@ standard tag: 'PLAC'
 
 specification:
   - A jurisdictional name to identify the place or location of an event.
-  - |
-    <PLACE_NAME>
-    "The name of the lowest jurisdiction that encompasses all lower-level places named in this source. For example, \"Oneida, Idaho\" would be used as a source jurisdiction place for events occurring in the various towns within Oneida County. \"Idaho\" would be the source jurisdiction place if the events recorded took place in other counties as well as Oneida County."
 
 label: 'Place'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-SOURCE_JURISDICTION_PLACE
 
 substructures: {}
 

--- a/output/structure/standard/SOUR-XREF_SOUR-DATA-DATE.yaml
+++ b/output/structure/standard/SOUR-XREF_SOUR-DATA-DATE.yaml
@@ -10,13 +10,10 @@ standard tag: 'DATE'
 
 specification:
   - The time of an event in a calendar format.
-  - |
-    <DATE_VALUE>
-    The date that this event data was entered into the original source document.
 
 label: 'Date'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-ENTRY_RECORDING_DATE
 
 substructures: {}
 

--- a/output/structure/standard/TEXT.yaml
+++ b/output/structure/standard/TEXT.yaml
@@ -10,13 +10,10 @@ standard tag: 'TEXT'
 
 specification:
   - The exact wording found in an original source document.
-  - |
-    <TEXT>
-    "A verbatim copy of any description contained within the source. This indicates notes or text that are actually contained in the source document, not the submitter's opinion about the source. This should be, from the evidence point of view, \"what the original record keeper said\" as opposed to the researcher's interpretation. The word TEXT, in this case, means from the text which appeared in the source record including labels."
 
 label: 'Text'
 
-payload: http://www.w3.org/2001/XMLSchema#string
+payload: https://gedcom.io/terms/v5.5.1/type-TEXT_FROM_SOURCE
 
 substructures: {}
 


### PR DESCRIPTION
This sets the correct payload type but does not yet create the yaml files for data types, which is left for issue #8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined GEDCOM schema specifications by updating generic type references to more precise, standardized definitions for various dates, record numbers, source details, and related fields.
	- Refined internal logic for identifying complex payload types, resulting in clearer and more accurate data representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->