### PR TITLE
Do manual validation of SEX payload

### DIFF
--- a/Gedcom551/GedcomStructure.cs
+++ b/Gedcom551/GedcomStructure.cs
@@ -778,6 +778,13 @@ namespace Gedcom551
                             GedcomStructureSchema.AddSchema(sourceProgram, tag, uri);
                             break;
                         }
+                        if (this.Schema.Uri == "https://gedcom.io/terms/v5.5.1/SEX")
+                        {
+                            if (this.LineVal != "M" && this.LineVal != "F" && this.LineVal != "U")
+                            {
+                                return ErrorMessage("\"" + this.LineVal + "\" is not a valid value for " + this.Tag);
+                            }
+                        }
                         // We currently don't do any further validation.
                         break;
                     case "https://gedcom.io/terms/v5.5.1/type-CHANGE_DATE": // TODO: should be DATE_EXACT

--- a/Tests/ValidationTests.cs
+++ b/Tests/ValidationTests.cs
@@ -667,8 +667,6 @@ namespace Tests
 ");
 
             // Try an invalid enum value.
-            // TODO: support SEX validation.
-#if false
             ValidateGedcomText(@"0 HEAD
 1 SOUR test
 1 SUBM @S1@
@@ -681,8 +679,22 @@ namespace Tests
 0 @I1@ INDI
 1 SEX UNKNOWN
 0 TRLR
-", new string[] { "Line 5: \"UNKNOWN\" is not a valid value for SEX" });
-#endif
+", new string[] { "Line 11: \"UNKNOWN\" is not a valid value for SEX" });
+            ValidateGedcomText(@"0 HEAD
+1 SOUR test
+1 SUBM @S1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR ASCII
+0 @S1@ SUBM
+1 NAME Test
+0 @SO1@ SOUR
+0 @I1@ INDI
+1 SOUR @SO1@
+2 EVEN CENSUS
+0 TRLR
+");
 
             // Try a valid structure name as an enum value.
             ValidateGedcomText(@"0 HEAD


### PR DESCRIPTION
Addresses part of #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation for the SEX field to ensure only valid entries ("M", "F", or "U") are accepted, resulting in clearer error messaging for invalid data.

- **Tests**
	- Updated and expanded the test suite to cover more comprehensive GEDCOM record scenarios, improving reliability and overall validation robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->