### PR TITLE
upgrade github workflow to use windows 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: Gedcom551.sln


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build workflow to use a newer Windows runner environment for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->