### PR TITLE
Add support for detecting some string base types

### DIFF
--- a/Gedcom551/Construct/GedcomStructureSchema.cs
+++ b/Gedcom551/Construct/GedcomStructureSchema.cs
@@ -303,7 +303,6 @@ namespace Gedcom551.Construct
                     continue;
                 }
 
-                string enumPattern = @"^(?!.*<)\s*\[.*\|.*\]\s*$";
                 string enumStart = @"^(?!.*<)\s*\[";
                 string enumEnd = @"\]\s*$";
 
@@ -321,6 +320,14 @@ namespace Gedcom551.Construct
                     }
                 }
 
+                string enumStringPattern = @"^\s*\[\s*[\w\s|(]*<[\w\s_]*>[\w\s|)]*\]\s*$";
+                if (Regex.Match(line, enumStringPattern).Success)
+                {
+                    schema.ActualPayload = "http://www.w3.org/2001/XMLSchema#string";
+                    continue;
+                }
+
+                string enumPattern = @"^(?!.*<)\s*\[.*\|.*\]\s*$";
                 Match match = Regex.Match(line, enumPattern);
                 if (match.Success)
                 {

--- a/Tests/SchemaTests.cs
+++ b/Tests/SchemaTests.cs
@@ -180,6 +180,15 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TestStringEnums()
+        {
+            VerifyUniqueTag("ROLE", XsdString);
+            VerifyQualifiedTag("INDI-NAME", "TYPE", XsdString);
+            VerifyPayloadTag("TYPE", "PHONETIC_TYPE", XsdString);
+            VerifyPayloadTag("TYPE", "ROMANIZED_TYPE", XsdString);
+        }
+
+        [TestMethod]
         public void TestPlacFone()
         {
             VerifyQualifiedTag("PLAC-PLACE_NAME", "FONE");
@@ -202,7 +211,7 @@ namespace Tests
             GedcomStructureSchema schema = GedcomStructureSchema.GetFinalSchemaByUri(GedcomStructureSchema.UriPrefix + tag + "-" + suffix);
             Debug.Assert(schema.StandardTag == tag);
             Debug.Assert(schema.Superstructures.Count > 1);
-            Debug.Assert(schema.OriginalPayload == payload);
+            Debug.Assert(schema.ActualPayload == payload);
             return schema;
         }
 
@@ -225,7 +234,7 @@ namespace Tests
         [TestMethod]
         public void TestFormPlaceHierarchy()
         {
-            VerifyPayloadTag("FORM", "PLACE_HIERARCHY", "PLACE_HIERARCHY");
+            VerifyPayloadTag("FORM", "PLACE_HIERARCHY", XsdString);
         }
     }
 }


### PR DESCRIPTION
Implements more of #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of enumeration values with generics, ensuring they are correctly treated as string payloads.

* **Tests**
  * Added new tests to verify that specific tags are assigned the correct string payload type.
  * Updated existing tests to check the actual payload type for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->